### PR TITLE
Change blog fonts to match the design

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -2,21 +2,21 @@
   <header>
   {% if index %}
     {% if post.external-url %}
-      <h1 class="text-3xl text-pink-500 my-3">
+      <h1 class="text-3xl my-3">
         <a href="{{ post.external-url }}">{% if site.titlecase %}{{ post.title | titlecase }} {% else %}{{ post.title }}{% endif %}</a> {% if post.external-url %}<a href="{{ root_url }}{{ post.url }}">&#8734;</a> {% endif %}
       </h1>
       {% else %}
-      <h1 class="text-3xl text-pink-500 my-3">
+      <h1 class="text-3xl my-3">
         <a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a>
       </h1>
       {% endif %}
       {% else %}
     {% if page.external-url %}
-      <h1 class="text-3xl text-pink-500 my-3">
+      <h1 class="text-3xl my-3">
         <a href="{{ page.external-url }}">{% if site.titlecase %}{{ page.title | titlecase }} {% else %}{{ page.title }}{% endif %}</a> &#8734;
       </h1>
       {% else %}
-      <h1 class="text-3xl text-pink-500 my-3">
+      <h1 class="text-3xl my-3">
         {% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}
       </h1>
     {% endif %}

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -32,14 +32,13 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/lib/jquery.min.js"%3E%3C/script%3E'))</script>
 
-  <!-- Typekit fonts -->
-  <script type="text/javascript" src="//use.typekit.net/xgt4lgm.js"></script>
-  <script type="text/javascript">try { Typekit.load(); } catch (e) { }</script>
+  <!-- Google fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Aleo:ital,wght@0,400;0,700;1,400&family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
 
-  
   <link rel="stylesheet" href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css">
   <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" href="https://use.typekit.net/fmw6nmr.css">
 
   {% include google_analytics.html %}
 

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -4,8 +4,7 @@
 <body {% if page.body_id %} id="{{ page.body_id }}" {% endif %}
   class="antialiased bg-white
   md:max-w-[1092px] mx-auto w-full 
-  text-black text-base font-light"
-  style="font-family: museo-sans, sans-serif;">
+  text-black text-base font-light">
   <header role="banner">{% include header.html %}</header>
   <nav role="navigation">{% include navigation.html %}</nav>
   <div id="main" class="pl-6 pr-8 md:px-12">

--- a/source/stylesheets/screen.css
+++ b/source/stylesheets/screen.css
@@ -22,9 +22,28 @@
 }
 
 html {
+    font-family: Poppins, sans-serif;
     scroll-behavior: smooth;
     --nilenso-pink: #FF3D84;
+    --nilenso-black: #000000;
     --grey: #4B5563;
+}
+
+p, p li, article {
+    font-family: Aleo, serif;
+}
+
+.monospaced {
+    font-size: 0.9em;
+}
+
+h1 {
+    font-weight: 600;
+    color: var(--nilenso-black);
+}
+
+h2, h3, h4 {
+    font-weight: 500;
 }
 
 #menuToggle {


### PR DESCRIPTION
The body font is now Aleo, and the headings are all in Poppins, to match [the design](https://www.figma.com/file/aFV2NmKJeArRMceHqwoIWX/Nilenso?node-id=1295%3A192&t=aj256xy1Dv0RDtyV-4).

For now, we also adjust the monospace font size to match it better with the main body font.

#### Not in scope of this PR
* Matching the new design exactly, we are only making the font styling match.
* Index page, fixing navigation between the main website and blog

### Before

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/24277692/210495199-7ac0a6ea-6613-4582-8bd2-8a494c8c35aa.png">

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/24277692/210495280-35436f5a-0cb5-4734-9994-43b7ee1ef8cd.png">

### After

<img width="967" alt="image" src="https://user-images.githubusercontent.com/24277692/210495089-6bf5f0a2-93fe-4e85-a694-1701b794974f.png">

<img width="965" alt="image" src="https://user-images.githubusercontent.com/24277692/210495249-93afdb70-d70f-4130-a441-457fb5b93267.png">
