### PR TITLE
Switch decap CMS to GitHub backend

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -48,14 +48,3 @@
 
 </head>
 
-<script>
-  if (window.netlifyIdentity) {
-    window.netlifyIdentity.on("init", (user) => {
-      if (!user) {
-        window.netlifyIdentity.on("login", () => {
-          document.location.href = "/admin/";
-        });
-      }
-    });
-  }
-</script>

--- a/source/admin/config.yml
+++ b/source/admin/config.yml
@@ -1,9 +1,12 @@
 site_url: https://blog.nilenso.com
 
 backend:
-  name: git-gateway
+  name: github
+  repo: nilenso/blog.nilenso.com
+  base_url: https://blog.nilenso.com
   branch: master # Branch to update (optional; defaults to master)
   squash_merges: true
+  auth_endpoint: /api/auth
 
 media_folder: "source/images/blog" # Media files will be stored in the repo under images/uploads
 public_folder: "/images/blog"

--- a/source/admin/index.html
+++ b/source/admin/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Content Manager</title>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Decap CMS -->


### PR DESCRIPTION
## Summary
- drop Netlify Identity scripts
- configure Decap CMS to use the GitHub backend with `/api/auth`
- set `base_url` so the OAuth endpoint resolves to our site

## Testing
- `bundle exec jekyll build` *(fails: rbenv: version `3.3.0` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842c06e09a4832a91fbfa84a76096df