### PR TITLE
Add blog post table of contents

### DIFF
--- a/source/_includes/post/toc.html
+++ b/source/_includes/post/toc.html
@@ -1,0 +1,3 @@
+<aside id="post-toc" class="post-toc" aria-label="Table of contents">
+  <nav><ol class="post-toc-list"></ol></nav>
+</aside>

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -4,6 +4,7 @@ single: true
 ---
 
 <div>
+{% include post/toc.html %}
 <article class="hentry" role="article">
   {% if page.cover_image %}
     <div class="cover-image-container">
@@ -38,6 +39,8 @@ single: true
   </section>
 {% endif %}
 </div>
+
+<script src="{{ root_url }}/javascripts/post-toc.js"></script>
 <!-- {% unless page.sidebar == false %}
 <aside class="sidebar">
   {% if site.post_asides.size %}

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -4,7 +4,9 @@ single: true
 ---
 
 <div>
-{% include post/toc.html %}
+{% if page.table_of_contents == true %}
+  {% include post/toc.html %}
+{% endif %}
 <article class="hentry" role="article">
   {% if page.cover_image %}
     <div class="cover-image-container">
@@ -40,7 +42,9 @@ single: true
 {% endif %}
 </div>
 
+{% if page.table_of_contents == true %}
 <script src="{{ root_url }}/javascripts/post-toc.js"></script>
+{% endif %}
 <!-- {% unless page.sidebar == false %}
 <aside class="sidebar">
   {% if site.post_asides.size %}

--- a/source/_posts/2026-05-18-evals-before-prompts-building-an-llm-ocr-for-kyc.md
+++ b/source/_posts/2026-05-18-evals-before-prompts-building-an-llm-ocr-for-kyc.md
@@ -5,6 +5,7 @@ kind: article
 created_at: 2026-05-18 10:00 -0800
 description: Building an evaluation framework for production-grade document extraction.
 author: Priyanga P Kini
+table_of_contents: true
 ---
 
 KYC, or Know Your Customer, is how banks, fintechs, and a growing number of businesses verify that a person is who they claim to be. At the heart of it sits a deeply unglamorous task: typing the fields off a scanned PAN card or Aadhaar into a form. Humans are bad at this. It's boring, error-prone, and, at scale, expensive. Can an LLM do it instead?

--- a/source/_posts/2026-06-25-sandboxing-ai-agents.md
+++ b/source/_posts/2026-06-25-sandboxing-ai-agents.md
@@ -5,6 +5,7 @@ kind: article
 created_at: 2026-06-25 10:00 -0800
 description: How we sandbox a code-research agent that analyses untrusted repositories
 author: Priyanga P Kini
+table_of_contents: true
 ---
 
 Everyone is racing to add LLMs to their systems. At the same time, nobody wants an agent running loose with access to the filesystem or the network. You definitely do not want an agent sending your data back home.

--- a/source/javascripts/post-toc.js
+++ b/source/javascripts/post-toc.js
@@ -1,0 +1,162 @@
+(function () {
+  var TOC_SELECTOR = '#post-toc';
+  var LIST_SELECTOR = '.post-toc-list';
+  var ARTICLE_SELECTOR = '.entry-content';
+  var TITLE_SELECTOR = '.hentry header h1';
+  var HEADING_SELECTOR = 'h2, h3';
+  var MIN_HEADINGS = 2;
+  var ACTIVE_CLASS = 'is-active';
+  var TITLE_ID = 'post-top';
+
+  function slugify(text) {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-');
+  }
+
+  function ensureUniqueId(heading, used) {
+    if (heading.id) {
+      used[heading.id] = true;
+      return;
+    }
+    var base = slugify(heading.textContent) || 'section';
+    var slug = base;
+    var n = 2;
+    while (used[slug] || document.getElementById(slug)) {
+      slug = base + '-' + n++;
+    }
+    used[slug] = true;
+    heading.id = slug;
+  }
+
+  function buildItem(level, text, href) {
+    var li = document.createElement('li');
+    li.className = 'post-toc-item post-toc-' + level;
+    var a = document.createElement('a');
+    a.href = href;
+    a.textContent = text;
+    li.appendChild(a);
+    return { li: li, link: a };
+  }
+
+  function scrollToHeading(heading) {
+    heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (history.replaceState) {
+      history.replaceState(null, '', '#' + heading.id);
+    }
+  }
+
+  function scrollToTop() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (history.replaceState) {
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+  }
+
+  function bindTocLink(link, state, onNavigate) {
+    link.addEventListener('click', function (event) {
+      event.preventDefault();
+      activate(link, state);
+      onNavigate();
+    });
+  }
+
+  function appendTitleEntry(list, pageTitle, state) {
+    if (!pageTitle) return null;
+    if (!pageTitle.id) pageTitle.id = TITLE_ID;
+    var item = buildItem('h1', pageTitle.textContent.trim(), '#');
+    bindTocLink(item.link, state, scrollToTop);
+    list.appendChild(item.li);
+    return item.link;
+  }
+
+  function appendHeadingEntries(list, headings, state) {
+    var used = {};
+    var links = {};
+    headings.forEach(function (heading) {
+      ensureUniqueId(heading, used);
+      var item = buildItem(heading.tagName.toLowerCase(), heading.textContent, '#' + heading.id);
+      bindTocLink(item.link, state, function () {
+        scrollToHeading(heading);
+      });
+      list.appendChild(item.li);
+      links[heading.id] = item.link;
+    });
+    return links;
+  }
+
+  function activate(link, state) {
+    if (!link || state.current === link) return;
+    if (state.current) state.current.classList.remove(ACTIVE_CLASS);
+    link.classList.add(ACTIVE_CLASS);
+    state.current = link;
+  }
+
+  function isNearPageBottom() {
+    return window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 4;
+  }
+
+  function observeHeadings(targets, linksById, state) {
+    if ('IntersectionObserver' in window) {
+      var observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+            var link = linksById[entry.target.id];
+            if (link) activate(link, state);
+          });
+        },
+        { rootMargin: '0px 0px -75% 0px', threshold: 0 }
+      );
+      targets.forEach(function (target) { observer.observe(target); });
+    }
+
+    function syncLastHeadingAtPageBottom() {
+      if (!targets.length || !isNearPageBottom()) return;
+      var lastHeading = targets[targets.length - 1];
+      activate(linksById[lastHeading.id], state);
+    }
+
+    window.addEventListener('scroll', syncLastHeadingAtPageBottom, { passive: true });
+    window.addEventListener('resize', syncLastHeadingAtPageBottom);
+    syncLastHeadingAtPageBottom();
+  }
+
+  function init() {
+    var toc = document.querySelector(TOC_SELECTOR);
+    if (!toc) return;
+    var list = toc.querySelector(LIST_SELECTOR);
+    var article = document.querySelector(ARTICLE_SELECTOR);
+    if (!article || !list) {
+      toc.style.display = 'none';
+      return;
+    }
+    var headings = article.querySelectorAll(HEADING_SELECTOR);
+    if (headings.length < MIN_HEADINGS) {
+      toc.style.display = 'none';
+      return;
+    }
+    var state = { current: null };
+    var pageTitle = document.querySelector(TITLE_SELECTOR);
+    var titleLink = appendTitleEntry(list, pageTitle, state);
+    var headingLinks = appendHeadingEntries(list, headings, state);
+    var linksById = {};
+    if (pageTitle && titleLink) linksById[pageTitle.id] = titleLink;
+    Object.keys(headingLinks).forEach(function (id) { linksById[id] = headingLinks[id]; });
+
+    activate(titleLink || headingLinks[headings[0].id], state);
+
+    var observed = Array.prototype.slice.call(headings);
+    if (pageTitle) observed.unshift(pageTitle);
+    observeHeadings(observed, linksById, state);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/source/stylesheets/screen.css
+++ b/source/stylesheets/screen.css
@@ -724,3 +724,144 @@ details pre.highlight,
   white-space: pre-wrap;
   word-wrap: break-word;
 }
+
+/* Post table of contents — Notion-style minimal sticky rail on the right */
+.post-toc {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .post-toc {
+    display: block;
+    position: fixed;
+    top: 35%;
+    right: 1rem;
+    transform: translateY(-50%);
+    max-height: 70vh;
+    z-index: 10;
+    font-family: var(--font-sans);
+  }
+}
+
+.post-toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  align-items: flex-end;
+}
+
+.post-toc-item {
+  margin: 0;
+  line-height: 1;
+}
+
+.post-toc-item a {
+  display: block;
+  position: relative;
+  text-decoration: none;
+  color: transparent;
+  font-size: 0.78rem;
+  white-space: nowrap;
+  padding: 0.05rem 0;
+  transition: color 0.15s ease;
+}
+
+.post-toc-h1 a {
+  font-weight: 600;
+}
+
+/* Default state: each item is a small horizontal bar */
+.post-toc-item a::before {
+  content: '';
+  display: block;
+  height: 1px;
+  background: #bdbdbd;
+  width: 18px;
+  margin-left: auto;
+  transition: background 0.15s ease, width 0.15s ease;
+}
+
+.post-toc-h1 a::before {
+  width: 28px;
+  height: 2px;
+  background: #8f8f8f;
+}
+
+.post-toc-h3 a::before {
+  width: 12px;
+}
+
+.post-toc-item a.is-active::before {
+  background: var(--nilenso-pink);
+  width: 22px;
+}
+
+.post-toc-h1 a.is-active::before {
+  width: 28px;
+}
+
+.post-toc-h3 a.is-active::before {
+  width: 16px;
+}
+
+/* On hover of the whole TOC, reveal text labels and hide the bars */
+.post-toc:hover {
+  background: #ffffff;
+  border: 1px solid #d6d6d6;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
+  width: max-content;
+  max-width: min(16rem, calc(100vw - 3rem));
+}
+
+.post-toc:hover .post-toc-item a {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: #555;
+}
+
+.post-toc:hover .post-toc-list {
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+.post-toc:hover .post-toc-item a::before {
+  display: none;
+}
+
+.post-toc:hover .post-toc-h1 a {
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 0.15rem;
+}
+
+.post-toc:hover .post-toc-h2 a {
+  padding-left: 0.75rem;
+}
+
+.post-toc:hover .post-toc-h3 a {
+  padding-left: 1.25rem;
+  font-size: 0.74rem;
+}
+
+.post-toc:hover .post-toc-item a:hover,
+.post-toc:hover .post-toc-item a:focus-visible {
+  color: #000;
+  font-weight: 500;
+}
+
+.post-toc:hover .post-toc-item a:focus-visible {
+  outline: none;
+}
+
+.post-toc:hover .post-toc-item a.is-active {
+  color: var(--nilenso-pink);
+  font-weight: 500;
+}
+


### PR DESCRIPTION
## Because
- blog posts need a reusable table of contents instead of hand-authored TOC blocks
- the TOC should be enabled only for posts that opt in via frontmatter

## This addresses
- adds a post TOC include and post-specific script wiring
- renders the TOC only when `table_of_contents: true` is set in post frontmatter
- enables the TOC for:
  - `blog/2026/06/25/sandboxing-ai-agents/`
  - `blog/2026/05/18/evals-before-prompts-building-an-llm-ocr-for-kyc/`

## Test Plan
- [x] Changes reviewed in code
- [x] Site preview checked manually
- [x] Linter/formatter clean
